### PR TITLE
Removed courses no. 1, 11, and 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ As a follow Up to the course project should be collected and presented.
 
 # Course
 
-#### 33 HelloRuby Computer Thinking for Kids
+#### 30 HelloRuby Computer Thinking for Kids
 - Format: short workshops 2 x 45 min with break
 - Content: games/lessons from HelloRuby http://www.helloruby.com/
 - Participants: 5 kids per workshop, 5-7- y.o.
@@ -58,227 +58,205 @@ As a follow Up to the course project should be collected and presented.
 - Start: September 2017
 - At least first 3 for free (testing phase)
 
-#### 32 GraphQL mit React-Apollo Client **Thomas Vogel**
+#### 29 GraphQL mit React-Apollo Client **Thomas Vogel**
  - Format: 4 hours
  - Content: How to use React-Apollo Client
  - Participants: 8-12
  - Preparations: bring your own laptop with running [react-create-app](https://github.com/facebookincubator/create-react-app)
  - Price: for free, part of Agent-Conf promotion tour 
 
-#### 31 3D printing for the masses **Jim van Hazendonk**
+#### 28 3D printing for the masses **Jim van Hazendonk**
  - Format: 4 hours
  - Content: What is 3D printing and how do I get started. Learn what different 3D printing techniques exist and how to best prepare objects for printing. From thingiverse to thing in hand.
  - Participants: 8-12
  - Preparations: bring your own laptop (need basic 3D understanding)
  - Price: €20
 
-#### 30 Getting started with Elasticsearch 5 **Johannes Wachter**
+#### 27 Getting started with Elasticsearch 5 **Johannes Wachter**
  - Format:
  - Content: Elasticsearch Introduction, Search API, Mapping, Distribution Model (Nodes, Cluster, Replication)
  - Participants: 5-10
  - Preparations: Bring your own laptop.
  - Price:
 
-#### 29 Realtime 1 Million particle simulation on the GPU  **Patrick Fürst**
+#### 26 Realtime 1 Million particle simulation on the GPU  **Patrick Fürst**
  - Format: 1 Day
  - Content: Learn how to use GPU based simulation techniques. How to use shaders for calculation and how to set up a simulation pipeline.
  - Participants: 5-10
  - Preparations: Basic knowledge of GPU programming and understanding of computer graphics. Laptop/Computer with a discrete GPU and support of OpenGL 4.3 or higher. We us the [Cinder](https://libcinder.org/) library as a starting point.    
  - Price: 20€
 
-#### 28 Introduction to WebGL and GPU rendering with Three.js **Patrick Fürst**
+#### 25 Introduction to WebGL and GPU rendering with Three.js **Patrick Fürst**
  - Format: 1 Day
  - Content: Learn the basics of realtime rendering and computer graphics by creating a small 3D project with [ThreeJS](https://threejs.org/)
  - Participants: 5-10
  - Preparations: Basic programming skills. Bring your own laptop. Needs to be [WebGL](https://get.webgl.org/) capable
  - Price: Free
 
-#### 27 Lowpoly landscaping for Virtual worlds in Blender **Jim van Hazendonk**
+#### 24 Lowpoly landscaping for Virtual worlds in Blender **Jim van Hazendonk**
  - Format: 2x3 hours
  - Content: Learn how to create low poly environments for [VR](https://skfb.ly/JRwP) or [city planning](https://skfb.ly/DXGC) or [exotic racegames](https://skfb.ly/DXGC)
  - Participants: 8-12
  - Preparations: bring your own laptop (need to know basics of blender )
  - Price: €30 (€5 discount for course 23 attendees)
 
-#### 26 InkScape and Blender for 3D printing **Jim van Hazendonk**
+#### 23 InkScape and Blender for 3D printing **Jim van Hazendonk**
  - Format: 2x3 hours
  - Content: Learn how to create 3D printable objects using Blender and Inkscape
  - Participants: 8-12
  - Preparations: bring your own laptop (need to know basics of blender and inkscape)
  - Price: €30
 
-#### 25 Getting started with InkScape **Jim van Hazendonk**
+#### 22 Getting started with InkScape **Jim van Hazendonk**
  - Format: 4 hours
  - Content: Learn how to create vector graphics to be used for logo design or 3D printing
  - Participants: 8-12
  - Preparations: bring your own laptop (needs [Inkscape](https://inkscape.org/en/download/) installed) 
  - Price: €20
 
-#### 24 Visuals & Projection Mapping in a Live or Installation Environment **Raphael Kuster**
+#### 21 Visuals & Projection Mapping in a Live or Installation Environment **Raphael Kuster**
  - Format: 2h - more specific to interests
  - Content: What is Projection Mapping? How can you use the content and the spaces? Softwares
  - Participants: 5 - 10
  - Preparations: none - just a theoretical a overview
  - Price: 10€
 
-#### 23 Getting started with Blender3D **Jim van Hazendonk**
+#### 20 Getting started with Blender3D **Jim van Hazendonk**
  - Format: 4 hours
  - Content: How does Blender work and start creating 3D models
  - Participants: 8-12
  - Preparations: Bring your own laptop (needs [Blender](https://www.blender.org/download/) installed)
  - Price: €20
 
-#### 22 Using low cost wifi equipment for building rural networks **Fabian Friesenecker**
+#### 19 Using low cost wifi equipment for building rural networks **Fabian Friesenecker**
  - Format:
  - Content:
  - Participants:
  - Preparations:
  - Price:
 
-#### 21 Arduino for Kids **Christian Anselmi**
+#### 18 Arduino for Kids **Christian Anselmi**
  - Format:
  - Content:
  - Participants:
  - Preparations:
  - Price:
 
-#### 20 All about sailing on the lake of Constance **Christian Anselmi**
+#### 17 All about sailing on the lake of Constance **Christian Anselmi**
  - Format:
  - Content:
  - Participants:
  - Preparations:
  - Price:
 
-#### 19 HTTP Caching for Webengineers **Thomas Schedler**
+#### 16 HTTP Caching for Webengineers **Thomas Schedler**
  - Format: 2 x 3 hours
  - Content: HTTP Caching with Varnish - from the basics to the advanced topics like ESI, tagging and context based caching.
  - Participants: Up to 10. Webdeveloper / DevOps
  - Preparations: You need a Laptop
  - Price: free
 
-#### 18 Battle Robots for Beginners **Johannes Moser**
+#### 15 Battle Robots for Beginners **Johannes Moser**
  - Format: 4 x 3 hours
  - Content: I'm an absolut Beginner at building battle robots, but I want to become an expert with a small group of people.
  - Participants: 5 to 8 Battle Robot Enthusiats (Developers, Do-It-Yourselfers, Electricians)
  - Preparations: We will buy Arduino Stuff together.
  - Price: The gear we will buy.
 
-#### 17 PhaserJS for Kids with **Johannes Moser**
+#### 14 PhaserJS for Kids with **Johannes Moser**
  - Format: 4 x 3 hours
  - Content: We will design and code a small game together, that will run in the browser.
  - Participants: 8 kids from 10 to 14.
  - Preparations: A laptop is required.
  - Price: Free
 
-#### 16 Getting started with Sketchup and Rhino3D **Guntram Bechtold**
+#### 13 Getting started with Sketchup and Rhino3D **Guntram Bechtold**
  - Format: 2 x 3 hrs
  - Content: Get familiar with the Concept
  - Participants: Up to 15 Participants. Any Age. You got to be an Internet User, basic knowledge.
  - Preparations: You need a Laptop and Sketchup and Rhino installed, at least as as a trial version
  - Price: free
 
-#### 15 Programming with Kids: The ultimate Scratch Course **Christian Anselmi**
+#### 12 Programming with Kids: The ultimate Scratch Course **Christian Anselmi**
  - Format:
  - Content:
  - Participants:
  - Preparations:
  - Price:
 
-#### 14 Getting started with Sulu.io **Thomas Schedler**
+#### 11 Getting started with Sulu.io **Thomas Schedler**
  - Format: 2 x 3 hours
  - Content: Getting started with Sulu.io & how to leverage the power of a Framework based CMS
  - Participants: Up to 10. Webdeveloper with basic PHP knowledge. Symfony would be an advantage.
  - Preparations: You need a Laptop
  - Price: free
 
-#### 13 10 Steps: Wordpress from zero to hero **Guntram Bechtold**
+#### 10 10 Steps: Wordpress from zero to hero **Guntram Bechtold**
  - Format: 4x3 hrs
  - Content: Getting started with Wordpress, Installation, Usage, Online Marketing Basics
  - Participants: Up to 15 Participants. Any Age. You got to be an Internet User, basic knowledge.
  - Preparations: You need a Laptop
  - Price: 80 EUR (30 days Money back guarantee)
 
-#### 12 Getting into Magento **Mike**
- - Format:
- - Content:
- - Participants:
- - Preparations:
- - Price:
-
-#### 11 The insights of Webassembly **Fabian Allgäuer**
- - Format:
- - Content:
- - Participants:
- - Preparations:
- - Price:
-
-#### 10 The nuts and bolts of Ansible **Christian Leitgeb**
+#### 09 The nuts and bolts of Ansible **Christian Leitgeb**
  - Format: 4h
  - Content: Introduction to Systems Managment in general (theoretical) and basics of Ansible.
  - Participants: 5-15
  - Preparations: some Linux and CLI Knowledge is a good preparation.
  - Price:
 
-#### 09 Building Apps with ReactNative **Speaker Wanted**
+#### 08 Building Apps with ReactNative **Speaker Wanted**
  - Format:
  - Content:
  - Participants:
  - Preparations:
  - Price:
 
-#### 08 On fire for ReactJS **Daniel Rotter**
+#### 07 On fire for ReactJS **Daniel Rotter**
  - Format: 3h
  - Content: Basic introduction to ReactJS by building a sample application.
  - Participants: 15
  - Preparations: Should have at least basic programming knowledge, preferable in JavaScript. Bring your own Laptop.
  - Price: free
 
-#### 07 Introduction to HTML/CSS **Phuc Le**
+#### 06 Introduction to HTML/CSS **Phuc Le**
  - Format: 4x4 hrs
  - Content: Getting started with HTML/CSS
  - Participants: Up to 5 Participants
  - Preparations: Bring a Laptop
  - Price: 300 EUR
 
-#### 06 Getting started with Continous Delivery **Christian Leitgeb**
+#### 05 Getting started with Continous Delivery **Christian Leitgeb**
  - Format: 4h
  - Content: Continous Delivery vs Continous Integration, Introduction to different Products (Cloud: Travis CI, Bitbucket Pipelines, Heroku - OnPremise: Microsoft TFS, Atlassian Bamboo, Jenkins). Audience can decide which tool will be shown during course.
  - Participants: 5-15
  - Preparations: Knowledge of at least 1 programming language
  - Price: free
 
-#### 05 Getting started with Docker & Virtualization **Christian Leitgeb**
+#### 04 Getting started with Docker & Virtualization **Christian Leitgeb**
  - Format: 4h
  - Content: Introduction to different technogies of Virtualization and how they are used, focus on trending topic Docker and topics interesting for developers.
  - Participants: 5-15
  - Preparations: interest in this topic
  - Price: free
 
-#### 04 Getting started with Meteor JS  **Christian Leitgeb**
+#### 03 Getting started with Meteor JS  **Christian Leitgeb**
  - Format:
  - Content: 
  - Participants:
  - Preparations:
  - Price:
 
-#### 03 IoT for Rookies **Christian Anselmi**
+#### 02 IoT for Rookies **Christian Anselmi**
  - Format:
  - Content:
  - Participants:
  - Preparations:
  - Price:
 
-#### 02 Create Website Layouts easily with CSS display: grid **Phuc Le**
+#### 01 Create Website Layouts easily with CSS display: grid **Phuc Le**
  - Format: 2h
  - Content: Introduction and workshop to CSS display grid property
  - Participants: 8 - 12
  - Preparations: Laptop
  - Price: 15
-
-#### 01 Getting started with PHP  **Fabian Allgäuer**
- - Format:
- - Content:
- - Participants:
- - Preparations:
- - Price:
-#### 


### PR DESCRIPTION
Removes the courses no. 1, 11, and 12.

I **will** re-add the PHP course in the future. Großes Indianerehrenwort! :heart: Unfortunately, I currently do not have time to plan and organize such course (i.e. until 2018).

Same for course 11. Plus, I think that this topic is better covered at a “VlbgWebDev”.

Course 12 has been removed as @michaelzangerle developed a strong aversion against Magento. It would surprise me if he voluntarily works with Magento in his free time :wink: